### PR TITLE
Fixing duplicate data in article index page during local development

### DIFF
--- a/src/components/layout/articles/clientContainer.tsx
+++ b/src/components/layout/articles/clientContainer.tsx
@@ -44,7 +44,7 @@ export default function ArticlesClientContainer({
       );
       const data: WpArticlesResult = await response.json();
 
-      if (data.posts.length) setArticles((old) => [...old, ...data.posts]);
+      if (data.posts.length) setArticles(data.posts);
       if (data.pageInfo) setPageInfo(data.pageInfo);
 
       setIsLoading(false);


### PR DESCRIPTION
Updating how `setArticles` is used, now replaces data on page load